### PR TITLE
Fix bug ip format

### DIFF
--- a/agent/whois_ip_agent.py
+++ b/agent/whois_ip_agent.py
@@ -41,7 +41,7 @@ class WhoisIPAgent(agent.Agent, persist_mixin.AgentPersistMixin):
                 if not self.set_add('agent_whois_ip_asset', host):
                     logger.info('target %s was processed before, exiting', host)
                     return
-                mask = '/32'
+                mask = '32'
                 version = ip.version
                 logger.info('processing IP %s', host)
                 try:


### PR DESCRIPTION
IN Some Agents (Nuclei, Nmap, Ip2Geo) the format of the inselector IP is not correct after the IP two slaches are added example:
8.8.8.8//24