### PR TITLE
Set strict to False when passing host address to ip_network.

### DIFF
--- a/agent/whois_ip_agent.py
+++ b/agent/whois_ip_agent.py
@@ -58,7 +58,7 @@ class WhoisIPAgent(agent.Agent, persist_mixin.AgentPersistMixin):
             mask = message.data.get('mask')
 
             if mask is not None:
-                addresses = ipaddress.ip_network(f'{host}/{mask}')
+                addresses = ipaddress.ip_network(f'{host}/{mask}', strict=False)
                 if not self.add_ip_network('agent_whois_ip_asset', addresses):
                     logger.info('target %s was processed before, exiting', addresses)
                     return


### PR DESCRIPTION
The ipaddress.ip_network() expect a network address as an input, to auto-transform a host address to its corresponding network address, the __strict__ argument must be set to False. 