### PR TITLE
Feat : Add CIDR Limit

### DIFF
--- a/agent/whois_ip_agent.py
+++ b/agent/whois_ip_agent.py
@@ -121,11 +121,13 @@ class WhoisIPAgent(agent.Agent, persist_mixin.AgentPersistMixin):
             network = ipaddress.ip_network(f"{host}")
         else:
             version = message.data.get("version")
-            if version == 4 and int(mask) < IPV4_CIDR_LIMIT:
+            if version not in (4, 6):
+                raise ValueError(f"Incorrect ip version {version}.")
+            elif version == 4 and int(mask) < IPV4_CIDR_LIMIT:
                 raise ValueError(
                     f"Subnet mask below {IPV4_CIDR_LIMIT} is not supported."
                 )
-            if version == 6 and int(mask) < IPV6_CIDR_LIMIT:
+            elif version == 6 and int(mask) < IPV6_CIDR_LIMIT:
                 raise ValueError(
                     f"Subnet mask below {IPV6_CIDR_LIMIT} is not supported."
                 )

--- a/agent/whois_ip_agent.py
+++ b/agent/whois_ip_agent.py
@@ -64,11 +64,11 @@ class WhoisIPAgent(agent.Agent, persist_mixin.AgentPersistMixin):
             None
         """
         logger.debug("processing message of selector %s", message.selector)
-
+        host = message.data.get("host")
         if message.selector.startswith("v3.asset.domain_name.dns_record"):
             return self._process_dns_record(message)
-        else:
-            return self._process_ip(message)
+        elif host is not None:
+            return self._process_ip(message, host)
 
     def _is_domain_in_scope(self, domain: str) -> bool:
         """Check if a domain is in the scan scope with a regular expression."""
@@ -114,11 +114,10 @@ class WhoisIPAgent(agent.Agent, persist_mixin.AgentPersistMixin):
                 logger.info("target %s was processed before, exiting", host)
                 return
 
-    def _process_ip(self, message: m.Message) -> None:
-        host = message.data.get("host")
+    def _process_ip(self, message: m.Message, host: str) -> None:
         mask = message.data.get("mask")
         if mask is None:
-            network = ipaddress.ip_network(f"{host}")
+            network = ipaddress.ip_network(host)
         else:
             version = message.data.get("version")
             if version not in (4, 6):

--- a/agent/whois_ip_agent.py
+++ b/agent/whois_ip_agent.py
@@ -64,10 +64,10 @@ class WhoisIPAgent(agent.Agent, persist_mixin.AgentPersistMixin):
             None
         """
         logger.debug("processing message of selector %s", message.selector)
-        host = message.data.get("host")
         if message.selector.startswith("v3.asset.domain_name.dns_record"):
             return self._process_dns_record(message)
-        elif host is not None:
+        host = message.data.get("host")
+        if host is not None:
             return self._process_ip(message, host)
 
     def _is_domain_in_scope(self, domain: str) -> bool:

--- a/ostorlab.yaml
+++ b/ostorlab.yaml
@@ -1,6 +1,6 @@
 kind: Agent
 name: whois_ip
-version: 0.3.9
+version: 0.4.0
 image: images/cover.png
 description: |
   This repository is an implementation of [Ostorlab Agent](https://pypi.org/project/ostorlab/)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -109,3 +109,43 @@ def whois_ip_agent_with_scope_arg(
             healthcheck_port=random.randint(4000, 5000),
         )
         return whois_ip_agent.WhoisIPAgent(definition, settings)
+
+
+@pytest.fixture()
+def scan_message_ipv4_with_mask8() -> message.Message:
+    """Creates a message of type v3.asset.ip.v4 to be used by the agent for testing purposes."""
+    selector = "v3.asset.ip.v4"
+    msg_data = {"host": "192.168.1.17", "mask": "8", "version": 4}
+    return message.Message.from_data(selector, data=msg_data)
+
+
+@pytest.fixture()
+def scan_message_ipv4_with_mask16() -> message.Message:
+    """Creates a message of type v3.asset.ip.v4 to be used by the agent for testing purposes."""
+    selector = "v3.asset.ip.v4"
+    msg_data = {"host": "192.168.1.17", "mask": "16", "version": 4}
+    return message.Message.from_data(selector, data=msg_data)
+
+
+@pytest.fixture()
+def scan_message_ipv6_with_mask64() -> message.Message:
+    """Creates a message of type v3.asset.ip.v6 to be used by the agent for testing purposes."""
+    selector = "v3.asset.ip.v6"
+    msg_data = {
+        "host": "2001:db8:3333:4444:5555:6666:7777:8888",
+        "mask": "64",
+        "version": 6,
+    }
+    return message.Message.from_data(selector, data=msg_data)
+
+
+@pytest.fixture()
+def scan_message_ipv6_with_mask112() -> message.Message:
+    """Creates a message of type v3.asset.ip.v6 to be used by the agent for testing purposes."""
+    selector = "v3.asset.ip.v6"
+    msg_data = {
+        "host": "2001:db8:3333:4444:5555:6666:7777:8888",
+        "mask": "112",
+        "version": 6,
+    }
+    return message.Message.from_data(selector, data=msg_data)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -149,3 +149,15 @@ def scan_message_ipv6_with_mask112() -> message.Message:
         "version": 6,
     }
     return message.Message.from_data(selector, data=msg_data)
+
+
+@pytest.fixture()
+def scan_message_ipv_with_incorrect_version() -> message.Message:
+    """Creates a message of type v3.asset.ip with an incorrect version."""
+    selector = "v3.asset.ip"
+    msg_data = {
+        "host": "0.0.0.0",
+        "mask": "32",
+        "version": 5,
+    }
+    return message.Message.from_data(selector, data=msg_data)

--- a/tests/whois_ip_agent_test.py
+++ b/tests/whois_ip_agent_test.py
@@ -228,7 +228,7 @@ def testAgentWhoisIP_whenRDAPIsDown_shouldRetry(
     assert mock_request.call_count == 2
 
 
-def testPrepareTargets_whenIPv4AssetReachCIDRLimit_raiseValueError(
+def testWhoisIP_whenIPv4AssetReachCIDRLimit_raiseValueError(
     test_agent: whois_ip_agent.WhoisIPAgent,
     mocker: plugin.MockerFixture,
     scan_message_ipv4_with_mask8: message.Message,
@@ -243,7 +243,7 @@ def testPrepareTargets_whenIPv4AssetReachCIDRLimit_raiseValueError(
         test_agent.process(scan_message_ipv4_with_mask8)
 
 
-def testPrepareTargets_whenIPv4AssetDoesNotReachCIDRLimit_doesNotRaiseValueError(
+def testWhoisIP_whenIPv4AssetDoesNotReachCIDRLimit_doesNotRaiseValueError(
     test_agent: whois_ip_agent.WhoisIPAgent,
     mocker: plugin.MockerFixture,
     scan_message_ipv4_with_mask16: message.Message,
@@ -257,7 +257,7 @@ def testPrepareTargets_whenIPv4AssetDoesNotReachCIDRLimit_doesNotRaiseValueError
     test_agent.process(scan_message_ipv4_with_mask16)
 
 
-def testPrepareTargets_whenIPv6AssetReachCIDRLimit_raiseValueError(
+def testWhoisIP_whenIPv6AssetReachCIDRLimit_raiseValueError(
     test_agent: whois_ip_agent.WhoisIPAgent,
     mocker: plugin.MockerFixture,
     scan_message_ipv6_with_mask64: message.Message,
@@ -272,7 +272,7 @@ def testPrepareTargets_whenIPv6AssetReachCIDRLimit_raiseValueError(
         test_agent.process(scan_message_ipv6_with_mask64)
 
 
-def testPrepareTargets_whenIPv6AssetDoesNotReachCIDRLimit_doesNotRaiseValueError(
+def testWhoisIP_whenIPv6AssetDoesNotReachCIDRLimit_doesNotRaiseValueError(
     test_agent: whois_ip_agent.WhoisIPAgent,
     mocker: plugin.MockerFixture,
     scan_message_ipv6_with_mask112: message.Message,
@@ -284,3 +284,12 @@ def testPrepareTargets_whenIPv6AssetDoesNotReachCIDRLimit_doesNotRaiseValueError
     )
 
     test_agent.process(scan_message_ipv6_with_mask112)
+
+
+def testWhoisIP_whenIPAssetHasIncorrectVersion_raiseValueError(
+    test_agent: whois_ip_agent.WhoisIPAgent,
+    scan_message_ipv_with_incorrect_version: message.Message,
+) -> None:
+    """Test the CIDR Limit in case IP has incorrect version."""
+    with pytest.raises(ValueError, match="Incorrect ip version 5."):
+        test_agent.process(scan_message_ipv_with_incorrect_version)

--- a/tests/whois_ip_agent_test.py
+++ b/tests/whois_ip_agent_test.py
@@ -3,6 +3,7 @@ from typing import List, Dict
 
 from ostorlab.agent.message import message
 from pytest_mock import plugin
+import pytest
 
 from agent import whois_ip_agent
 
@@ -225,3 +226,61 @@ def testAgentWhoisIP_whenRDAPIsDown_shouldRetry(
 
     assert len(agent_mock) == 0
     assert mock_request.call_count == 2
+
+
+def testPrepareTargets_whenIPv4AssetReachCIDRLimit_raiseValueError(
+    test_agent: whois_ip_agent.WhoisIPAgent,
+    mocker: plugin.MockerFixture,
+    scan_message_ipv4_with_mask8: message.Message,
+) -> None:
+    """Test the CIDR Limit in case IPV4 and the Limit is reached."""
+    mocker.patch(
+        "ostorlab.agent.mixins.agent_persist_mixin.AgentPersistMixin.add_ip_network",
+        return_value=False,
+    )
+
+    with pytest.raises(ValueError, match="Subnet mask below 16 is not supported."):
+        test_agent.process(scan_message_ipv4_with_mask8)
+
+
+def testPrepareTargets_whenIPv4AssetDoesNotReachCIDRLimit_doesNotRaiseValueError(
+    test_agent: whois_ip_agent.WhoisIPAgent,
+    mocker: plugin.MockerFixture,
+    scan_message_ipv4_with_mask16: message.Message,
+) -> None:
+    """Test the CIDR Limit in case IPV4 and the Limit is not reached."""
+    mocker.patch(
+        "ostorlab.agent.mixins.agent_persist_mixin.AgentPersistMixin.add_ip_network",
+        return_value=False,
+    )
+
+    test_agent.process(scan_message_ipv4_with_mask16)
+
+
+def testPrepareTargets_whenIPv6AssetReachCIDRLimit_raiseValueError(
+    test_agent: whois_ip_agent.WhoisIPAgent,
+    mocker: plugin.MockerFixture,
+    scan_message_ipv6_with_mask64: message.Message,
+) -> None:
+    """Test the CIDR Limit in case IPV6 and the Limit is reached."""
+    mocker.patch(
+        "ostorlab.agent.mixins.agent_persist_mixin.AgentPersistMixin.add_ip_network",
+        return_value=False,
+    )
+
+    with pytest.raises(ValueError, match="Subnet mask below 112 is not supported."):
+        test_agent.process(scan_message_ipv6_with_mask64)
+
+
+def testPrepareTargets_whenIPv6AssetDoesNotReachCIDRLimit_doesNotRaiseValueError(
+    test_agent: whois_ip_agent.WhoisIPAgent,
+    mocker: plugin.MockerFixture,
+    scan_message_ipv6_with_mask112: message.Message,
+) -> None:
+    """Test the CIDR Limit in case IPV6 and the Limit is not reached."""
+    mocker.patch(
+        "ostorlab.agent.mixins.agent_persist_mixin.AgentPersistMixin.add_ip_network",
+        return_value=False,
+    )
+
+    test_agent.process(scan_message_ipv6_with_mask112)

--- a/tests/whois_ip_agent_test.py
+++ b/tests/whois_ip_agent_test.py
@@ -230,15 +230,9 @@ def testAgentWhoisIP_whenRDAPIsDown_shouldRetry(
 
 def testWhoisIP_whenIPv4AssetReachCIDRLimit_raiseValueError(
     test_agent: whois_ip_agent.WhoisIPAgent,
-    mocker: plugin.MockerFixture,
     scan_message_ipv4_with_mask8: message.Message,
 ) -> None:
     """Test the CIDR Limit in case IPV4 and the Limit is reached."""
-    mocker.patch(
-        "ostorlab.agent.mixins.agent_persist_mixin.AgentPersistMixin.add_ip_network",
-        return_value=False,
-    )
-
     with pytest.raises(ValueError, match="Subnet mask below 16 is not supported."):
         test_agent.process(scan_message_ipv4_with_mask8)
 
@@ -259,15 +253,9 @@ def testWhoisIP_whenIPv4AssetDoesNotReachCIDRLimit_doesNotRaiseValueError(
 
 def testWhoisIP_whenIPv6AssetReachCIDRLimit_raiseValueError(
     test_agent: whois_ip_agent.WhoisIPAgent,
-    mocker: plugin.MockerFixture,
     scan_message_ipv6_with_mask64: message.Message,
 ) -> None:
     """Test the CIDR Limit in case IPV6 and the Limit is reached."""
-    mocker.patch(
-        "ostorlab.agent.mixins.agent_persist_mixin.AgentPersistMixin.add_ip_network",
-        return_value=False,
-    )
-
     with pytest.raises(ValueError, match="Subnet mask below 112 is not supported."):
         test_agent.process(scan_message_ipv6_with_mask64)
 


### PR DESCRIPTION
**Enhancement Request: Set Maximum CIDR Prefix Length for Host Limitation**


```python
# Maximum CIDR prefix length to limit the number of hosts that can be scanned.
# For IPv4: Setting it to 16 (allowing for 2^(32-16) - 2 = 65,534 hosts).
# For IPv6: Setting it to 112 (allowing for 2^(128-112) = 65,536 hosts).
IPV4_CIDR_LIMIT = 16
IPV6_CIDR_LIMIT = 112
```

---