### PR TITLE
Handle ASNParseError during WHOIS lookup

### DIFF
--- a/agent/whois_ip_agent.py
+++ b/agent/whois_ip_agent.py
@@ -39,6 +39,7 @@ IPV6_CIDR_LIMIT = 112
     reraise=True,
 )
 def _get_whois_record(host: str) -> dict[str, Any]:
+    logger.info("host: %s", host)
     lookup_rdap = ipwhois.IPWhois(host).lookup_rdap()
     return cast(dict[str, Any], lookup_rdap)
 
@@ -64,7 +65,7 @@ class WhoisIPAgent(agent.Agent, persist_mixin.AgentPersistMixin):
         Returns:
             None
         """
-        logger.debug("processing message of selector %s", message.selector)
+        logger.info("processing message of selector %s", message.selector)
         if message.selector.startswith("v3.asset.domain_name.dns_record"):
             return self._process_dns_record(message)
         host = message.data.get("host")
@@ -153,14 +154,15 @@ class WhoisIPAgent(agent.Agent, persist_mixin.AgentPersistMixin):
                     ipwhois.exceptions.IPDefinedError,
                     ipwhois.exceptions.ASNRegistryError,
                     ipwhois.exceptions.HTTPLookupError,
+                    ipwhois.exceptions.ASNParseError,
                 ):
                     # Case where of the loopback address.
-                    logger.warning(
+                    logger.error(
                         "Some data not found when agent_whois_ip_asset try to process IP %s",
                         address,
                     )
                 except exceptions.HTTPRateLimitError:
-                    logger.warning("Rate limit error for IP %s", address)
+                    logger.info("Rate limit error for IP %s", address)
         else:
             logger.info("target %s was processed before, exiting", network)
             return

--- a/agent/whois_ip_agent.py
+++ b/agent/whois_ip_agent.py
@@ -155,16 +155,16 @@ class WhoisIPAgent(agent.Agent, persist_mixin.AgentPersistMixin):
                     ipwhois.exceptions.HTTPLookupError,
                 ):
                     # Case where of the loopback address.
-                    logger.error(
+                    logger.warning(
                         "Some data not found when agent_whois_ip_asset try to process IP %s",
                         address,
                     )
                 except ipwhois.exceptions.ASNParseError:
                     logger.error("ASN parse error for IP %s", address)
                 except exceptions.HTTPRateLimitError:
-                    logger.info("Rate limit error for IP %s", address)
+                    logger.warning("Rate limit error for IP %s", address)
         else:
-            logger.warning("target %s was processed before, exiting", network)
+            logger.info("target %s was processed before, exiting", network)
             return
 
     def _emit_whois_message(self, whois_message: Dict[str, Any]) -> None:

--- a/agent/whois_ip_agent.py
+++ b/agent/whois_ip_agent.py
@@ -153,13 +153,14 @@ class WhoisIPAgent(agent.Agent, persist_mixin.AgentPersistMixin):
                     ipwhois.exceptions.IPDefinedError,
                     ipwhois.exceptions.ASNRegistryError,
                     ipwhois.exceptions.HTTPLookupError,
-                    ipwhois.exceptions.ASNParseError,
                 ):
                     # Case where of the loopback address.
                     logger.error(
                         "Some data not found when agent_whois_ip_asset try to process IP %s",
                         address,
                     )
+                except ipwhois.exceptions.ASNParseError:
+                    logger.error("ASN parse error for IP %s", address)
                 except exceptions.HTTPRateLimitError:
                     logger.info("Rate limit error for IP %s", address)
         else:

--- a/agent/whois_ip_agent.py
+++ b/agent/whois_ip_agent.py
@@ -39,7 +39,6 @@ IPV6_CIDR_LIMIT = 112
     reraise=True,
 )
 def _get_whois_record(host: str) -> dict[str, Any]:
-    logger.info("host: %s", host)
     lookup_rdap = ipwhois.IPWhois(host).lookup_rdap()
     return cast(dict[str, Any], lookup_rdap)
 
@@ -65,7 +64,7 @@ class WhoisIPAgent(agent.Agent, persist_mixin.AgentPersistMixin):
         Returns:
             None
         """
-        logger.info("processing message of selector %s", message.selector)
+        logger.debug("processing message of selector %s", message.selector)
         if message.selector.startswith("v3.asset.domain_name.dns_record"):
             return self._process_dns_record(message)
         host = message.data.get("host")
@@ -164,7 +163,7 @@ class WhoisIPAgent(agent.Agent, persist_mixin.AgentPersistMixin):
                 except exceptions.HTTPRateLimitError:
                     logger.info("Rate limit error for IP %s", address)
         else:
-            logger.info("target %s was processed before, exiting", network)
+            logger.warning("target %s was processed before, exiting", network)
             return
 
     def _emit_whois_message(self, whois_message: Dict[str, Any]) -> None:

--- a/tests/whois_ip_agent_test.py
+++ b/tests/whois_ip_agent_test.py
@@ -354,8 +354,8 @@ def testWhoisIp_whenASNParseErrorOccure_logWithoutCrash(
     mocker: plugin.MockerFixture,
     agent_mock: List[message.Message],
     caplog: pytest.LogCaptureFixture,
-):
-    """Test that ASNParseError is caught and handled gracefully."""
+) -> None:
+    """Test that ASNParseError is caught and logged."""
     mocker.patch(
         "ipwhois.IPWhois.lookup_rdap", side_effect=ipwhois.exceptions.ASNParseError
     )

--- a/tests/whois_ip_agent_test.py
+++ b/tests/whois_ip_agent_test.py
@@ -363,6 +363,4 @@ def testWhoisIp_whenASNParseErrorOccure_logWithoutCrash(
     test_agent.process(scan_message_ipv4)
 
     assert len(agent_mock) == 0
-    assert (
-        "Some data not found when agent_whois_ip_asset try to process IP" in caplog.text
-    )
+    assert "ASN parse error for IP" in caplog.text


### PR DESCRIPTION
## Catches the ASNParserError exception

Add ASNParseError to handled exceptions to prevent crashes during `lookup_rdap`
[Ticket-os-12983](https://report.ostorlab.co/remediation/tickets/os-12983)
![image](https://github.com/user-attachments/assets/ddea3992-946e-49c4-bf51-e1fafab30bef)
