### PR TITLE
feature: expand ASN assets into announced networks

### DIFF
--- a/agent/ipwhois_data_handler.py
+++ b/agent/ipwhois_data_handler.py
@@ -1,12 +1,28 @@
-"""Helper module for preparing the whois IP messages."""
+"""Helper module for preparing WHOIS IP messages and ASN network ranges."""
 
+import collections.abc
+import http.client
 import ipaddress
+import json
 import logging
+import urllib.request
 from typing import Any
 
+import tenacity
 from ostorlab.agent.message import message as m
 
 logger = logging.getLogger(__name__)
+
+RIPE_ANNOUNCED_PREFIXES_URL = "https://stat.ripe.net/data/announced-prefixes/data.json"
+RIPE_LOOKUP_TIMEOUT_SECONDS = 15
+RIPE_LOOKUP_ATTEMPTS = 2
+RIPE_LOOKUP_RETRY_WAIT_SECONDS = 3
+RIPE_USER_AGENT = "agent_whois_ip"
+MAX_ASN_NUMBER = 4_294_967_295
+
+
+class RipeLookupError(Exception):
+    """Raised when the RIPE announced-prefixes lookup fails."""
 
 
 def prepare_whois_message_data(
@@ -87,3 +103,103 @@ def get_ips_from_dns_record_message(
         except ipaddress.AddressValueError as e:
             logger.error("%s", e)
     return ip_addresses
+
+
+def normalize_asn(asn: object) -> str:
+    """Normalize an ASN to the canonical ``AS<number>`` form.
+
+    Args:
+        asn: ASN value with or without the ``AS`` prefix.
+
+    Returns:
+        Canonical ASN value.
+
+    Raises:
+        ValueError: If the value is not a valid 32-bit ASN.
+    """
+    if not isinstance(asn, str):
+        raise ValueError(f"Invalid ASN: {asn!r}")
+    value = asn.strip()
+    if value[:2].lower() == "as":
+        value = value[2:]
+    if value.isascii() is False or value.isdecimal() is False:
+        raise ValueError(f"Invalid ASN: {asn!r}")
+    asn_number = int(value)
+    if asn_number <= 0 or asn_number > MAX_ASN_NUMBER:
+        raise ValueError(f"Invalid ASN: {asn!r}")
+    return f"AS{asn_number}"
+
+
+@tenacity.retry(
+    stop=tenacity.stop_after_attempt(RIPE_LOOKUP_ATTEMPTS),
+    wait=tenacity.wait_fixed(RIPE_LOOKUP_RETRY_WAIT_SECONDS),
+    retry=tenacity.retry_if_exception_type(RipeLookupError),
+    reraise=True,
+)
+def _fetch_ripe_prefixes(normalized_asn: str) -> list[object]:
+    """Fetch announced prefixes for an ASN from the public RIPE API."""
+    request = urllib.request.Request(
+        f"{RIPE_ANNOUNCED_PREFIXES_URL}?resource={normalized_asn}",
+        headers={"Accept": "application/json", "User-Agent": RIPE_USER_AGENT},
+    )
+    try:
+        with urllib.request.urlopen(
+            request, timeout=RIPE_LOOKUP_TIMEOUT_SECONDS
+        ) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+    except (
+        http.client.HTTPException,
+        OSError,
+        UnicodeError,
+        ValueError,
+    ) as error:
+        raise RipeLookupError(f"RIPE lookup failed for {normalized_asn}") from error
+
+    if not isinstance(payload, dict) or payload.get("status") != "ok":
+        raise RipeLookupError(
+            f"RIPE lookup returned an invalid status for {normalized_asn}"
+        )
+    data = payload.get("data")
+    if not isinstance(data, dict):
+        raise RipeLookupError(f"RIPE lookup returned invalid data for {normalized_asn}")
+    prefixes = data.get("prefixes")
+    if not isinstance(prefixes, list):
+        raise RipeLookupError(
+            f"RIPE lookup returned invalid prefixes for {normalized_asn}"
+        )
+    return [
+        prefix.get("prefix")
+        for prefix in prefixes
+        if isinstance(prefix, dict) and "prefix" in prefix
+    ]
+
+
+def get_networks_for_normalized_asn(
+    normalized_asn: str,
+) -> list[ipaddress.IPv4Network | ipaddress.IPv6Network]:
+    """Return normalized, exactly deduplicated prefixes announced by an ASN."""
+    return _normalize_networks(_fetch_ripe_prefixes(normalized_asn))
+
+
+def _normalize_networks(
+    cidrs: collections.abc.Iterable[object],
+) -> list[ipaddress.IPv4Network | ipaddress.IPv6Network]:
+    """Parse CIDRs and remove only exact canonical duplicates."""
+    networks: list[ipaddress.IPv4Network | ipaddress.IPv6Network] = []
+    seen: set[ipaddress.IPv4Network | ipaddress.IPv6Network] = set()
+    for cidr in cidrs:
+        if not isinstance(cidr, str):
+            logger.warning("ignoring non-string CIDR value: %r", cidr)
+            continue
+        candidate = cidr.strip()
+        if not candidate:
+            continue
+        try:
+            network = ipaddress.ip_network(candidate, strict=False)
+        except ValueError:
+            logger.warning("ignoring invalid network range: %s", candidate)
+            continue
+        if network not in seen:
+            seen.add(network)
+            networks.append(network)
+    return networks

--- a/agent/ipwhois_data_handler.py
+++ b/agent/ipwhois_data_handler.py
@@ -117,12 +117,9 @@ def normalize_asn(asn: object) -> str:
 
     Returns:
         Canonical ASN value.
-
-    Raises:
-        ValueError: If the value is not a valid 32-bit ASN.
     """
     if not isinstance(asn, str):
-        raise ValueError(f"Invalid ASN: {asn!r}")
+        raise TypeError(f"Invalid ASN: {asn!r}")
     value = asn.strip()
     if value[:2].lower() == "as":
         value = value[2:]

--- a/agent/ipwhois_data_handler.py
+++ b/agent/ipwhois_data_handler.py
@@ -21,7 +21,11 @@ RIPE_USER_AGENT = "agent_whois_ip"
 MAX_ASN_NUMBER = 4_294_967_295
 
 
-class RipeLookupError(Exception):
+class Error(Exception):
+    """Base error for the ipwhois data handler module."""
+
+
+class RipeLookupError(Error):
     """Raised when the RIPE announced-prefixes lookup fails."""
 
 

--- a/agent/whois_ip_agent.py
+++ b/agent/whois_ip_agent.py
@@ -30,6 +30,15 @@ MAX_RETRY_ATTEMPTS = 2
 WAIT_BETWEEN_RETRY = 3
 IPV4_CIDR_LIMIT = 16
 IPV6_CIDR_LIMIT = 112
+ASN_SELECTOR = "v3.asset.asn"
+ASN_PROCESSED_SET = "agent_whois_ip_asn_asset"
+ASN_CLAIM_KEY_PREFIX = "agent_whois_ip_asn_claim"
+NETWORK_PROCESSED_SET = "agent_whois_ip_network_asset"
+NETWORK_CLAIM_KEY_PREFIX = "agent_whois_ip_network_claim"
+
+
+class NetworkClaimError(RuntimeError):
+    """Raised when another worker is currently emitting the same network."""
 
 
 @tenacity.retry(
@@ -56,15 +65,17 @@ class WhoisIPAgent(agent.Agent, persist_mixin.AgentPersistMixin):
         self._scope_domain_regex: str | None = self.args.get("scope_domain_regex")
 
     def process(self, message: m.Message) -> None:
-        """Process DNS records and IP asset to emit whois record.
+        """Process DNS records, IP assets, and ASN assets.
 
         Args:
-            message: DNS record or IP asset message.
+            message: DNS record, IP asset, or ASN asset message.
 
         Returns:
             None
         """
         logger.debug("processing message of selector %s", message.selector)
+        if message.selector == ASN_SELECTOR:
+            return self._process_asn(message.data.get("asn"))
         if message.selector.startswith("v3.asset.domain_name.dns_record"):
             return self._process_dns_record(message)
         host = message.data.get("host")
@@ -166,6 +177,73 @@ class WhoisIPAgent(agent.Agent, persist_mixin.AgentPersistMixin):
         else:
             logger.info("target %s was processed before, exiting", network)
             return
+
+    def _process_asn(self, asn: object) -> None:
+        """Expand an ASN into the network ranges it currently announces."""
+        try:
+            normalized_asn = ipwhois_data_handler.normalize_asn(asn)
+        except ValueError:
+            logger.warning("invalid ASN value: %r", asn)
+            return
+
+        if self.set_is_member(ASN_PROCESSED_SET, normalized_asn):
+            logger.info("ASN %s was processed before, exiting", normalized_asn)
+            return
+
+        claim_key = f"{ASN_CLAIM_KEY_PREFIX}:{normalized_asn}"
+        if self.set_add(claim_key, normalized_asn) is False:
+            logger.info("ASN %s is already being processed", normalized_asn)
+            return
+
+        try:
+            if self.set_is_member(ASN_PROCESSED_SET, normalized_asn):
+                return
+            networks = ipwhois_data_handler.get_networks_for_normalized_asn(
+                normalized_asn
+            )
+            for network in networks:
+                self._emit_network_message(network)
+            self.set_add(ASN_PROCESSED_SET, normalized_asn)
+        finally:
+            try:
+                self.delete(claim_key)
+            except Exception:
+                logger.exception("failed to release ASN claim for %s", normalized_asn)
+
+    def _emit_network_message(
+        self, network: ipaddress.IPv4Network | ipaddress.IPv6Network
+    ) -> None:
+        """Emit one network message without enumerating any addresses."""
+        cidr = network.with_prefixlen
+        if self.set_is_member(NETWORK_PROCESSED_SET, cidr):
+            logger.info("network %s was emitted before, exiting", cidr)
+            return
+
+        claim_key = f"{NETWORK_CLAIM_KEY_PREFIX}:{cidr}"
+        if self.set_add(claim_key, cidr) is False:
+            if self.set_is_member(NETWORK_PROCESSED_SET, cidr):
+                return
+            raise NetworkClaimError(f"network {cidr} is already being emitted")
+
+        try:
+            if self.set_is_member(NETWORK_PROCESSED_SET, cidr):
+                return
+            data = {
+                "ips": [
+                    {
+                        "host": str(network.network_address),
+                        "mask": str(network.prefixlen),
+                        "version": network.version,
+                    }
+                ]
+            }
+            self.emit("v3.asset.network", data)
+            self.set_add(NETWORK_PROCESSED_SET, cidr)
+        finally:
+            try:
+                self.delete(claim_key)
+            except Exception:
+                logger.exception("failed to release network claim for %s", cidr)
 
     def _emit_whois_message(self, whois_message: dict[str, Any]) -> None:
         """Emit the whois message depending on the type of host address"""

--- a/agent/whois_ip_agent.py
+++ b/agent/whois_ip_agent.py
@@ -6,6 +6,7 @@ import re
 from typing import Any, cast
 
 import ipwhois
+import redis
 import tenacity
 from ipwhois import exceptions
 from ostorlab.agent import agent
@@ -207,7 +208,7 @@ class WhoisIPAgent(agent.Agent, persist_mixin.AgentPersistMixin):
         finally:
             try:
                 self.delete(claim_key)
-            except Exception:
+            except redis.exceptions.RedisError:
                 logger.exception("failed to release ASN claim for %s", normalized_asn)
 
     def _emit_network_message(
@@ -242,7 +243,7 @@ class WhoisIPAgent(agent.Agent, persist_mixin.AgentPersistMixin):
         finally:
             try:
                 self.delete(claim_key)
-            except Exception:
+            except redis.exceptions.RedisError:
                 logger.exception("failed to release network claim for %s", cidr)
 
     def _emit_whois_message(self, whois_message: dict[str, Any]) -> None:

--- a/agent/whois_ip_agent.py
+++ b/agent/whois_ip_agent.py
@@ -187,7 +187,7 @@ class WhoisIPAgent(agent.Agent, persist_mixin.AgentPersistMixin):
         """Expand an ASN into the network ranges it currently announces."""
         try:
             normalized_asn = ipwhois_data_handler.normalize_asn(asn)
-        except ValueError:
+        except (TypeError, ValueError):
             logger.warning("invalid ASN value: %r", asn)
             return
 

--- a/agent/whois_ip_agent.py
+++ b/agent/whois_ip_agent.py
@@ -38,7 +38,11 @@ NETWORK_PROCESSED_SET = "agent_whois_ip_network_asset"
 NETWORK_CLAIM_KEY_PREFIX = "agent_whois_ip_network_claim"
 
 
-class NetworkClaimError(RuntimeError):
+class Error(Exception):
+    """Base error for the whois IP agent module."""
+
+
+class NetworkClaimError(Error):
     """Raised when another worker is currently emitting the same network."""
 
 
@@ -202,8 +206,18 @@ class WhoisIPAgent(agent.Agent, persist_mixin.AgentPersistMixin):
             networks = ipwhois_data_handler.get_networks_for_normalized_asn(
                 normalized_asn
             )
+            contended_cidrs: list[str] = []
             for network in networks:
-                self._emit_network_message(network)
+                try:
+                    self._emit_network_message(network)
+                except NetworkClaimError:
+                    contended_cidrs.append(network.with_prefixlen)
+
+            if len(contended_cidrs) > 0:
+                raise NetworkClaimError(
+                    f"networks {', '.join(contended_cidrs)} are already being emitted"
+                )
+
             self.set_add(ASN_PROCESSED_SET, normalized_asn)
         finally:
             try:

--- a/ostorlab.yaml
+++ b/ostorlab.yaml
@@ -73,10 +73,12 @@ description: |
 in_selectors:
   - v3.asset.ip.v4
   - v3.asset.ip.v6
+  - v3.asset.asn
   - v3.asset.domain_name.dns_record
 out_selectors:
   - v3.asset.ip.v4.whois
   - v3.asset.ip.v6.whois
+  - v3.asset.network
 docker_file_path : Dockerfile
 docker_build_root : .
 args:

--- a/tests/ipwhois_data_handler_test.py
+++ b/tests/ipwhois_data_handler_test.py
@@ -7,7 +7,6 @@ from io import BytesIO
 from unittest import mock
 
 import pytest
-import tenacity
 from pytest_mock import plugin
 
 from agent import ipwhois_data_handler
@@ -16,14 +15,6 @@ from agent import ipwhois_data_handler
 def _json_response(payload: object) -> BytesIO:
     """Build a context-manager response containing a JSON payload."""
     return BytesIO(json.dumps(payload).encode("utf-8"))
-
-
-def _fetch_without_wait(normalized_asn: str) -> list[object]:
-    """Run the retrying RIPE fetch without sleeping in a unit test."""
-    fetch = ipwhois_data_handler._fetch_ripe_prefixes.retry_with(
-        wait=tenacity.wait_none()
-    )
-    return fetch(normalized_asn)
 
 
 @pytest.mark.parametrize(
@@ -65,7 +56,7 @@ def testNormalizeAsn_whenValueIsInvalid_raisesValueError(value: object) -> None:
         {"status": "ok", "data": {"prefixes": {}}},
     ],
 )
-def testFetchRipePrefixes_whenPayloadMalformed_raisesAfterRetries(
+def testGetNetworksForAsn_whenPayloadMalformed_raisesAfterRetries(
     payload: object, mocker: plugin.MockerFixture
 ) -> None:
     """Treat malformed RIPE envelopes as retryable lookup failures."""
@@ -76,7 +67,7 @@ def testFetchRipePrefixes_whenPayloadMalformed_raisesAfterRetries(
     open_mock = mocker.patch("urllib.request.urlopen", side_effect=responses)
 
     with pytest.raises(ipwhois_data_handler.RipeLookupError):
-        _fetch_without_wait("AS268302")
+        ipwhois_data_handler.get_networks_for_normalized_asn("AS268302")
 
     assert open_mock.call_count == ipwhois_data_handler.RIPE_LOOKUP_ATTEMPTS
 
@@ -89,7 +80,7 @@ def testFetchRipePrefixes_whenPayloadMalformed_raisesAfterRetries(
         http.client.IncompleteRead(b"partial", 10),
     ],
 )
-def testFetchRipePrefixes_whenTransportOrReadFails_convertsAndRetries(
+def testGetNetworksForAsn_whenTransportOrReadFails_convertsAndRetries(
     error: BaseException,
     mocker: plugin.MockerFixture,
 ) -> None:
@@ -100,13 +91,13 @@ def testFetchRipePrefixes_whenTransportOrReadFails_convertsAndRetries(
     )
 
     with pytest.raises(ipwhois_data_handler.RipeLookupError) as exc_info:
-        _fetch_without_wait("AS268302")
+        ipwhois_data_handler.get_networks_for_normalized_asn("AS268302")
 
     assert open_mock.call_count == ipwhois_data_handler.RIPE_LOOKUP_ATTEMPTS
     assert isinstance(exc_info.value.__cause__, type(error))
 
 
-def testFetchRipePrefixes_whenFirstResponseFails_retriesAndReturnsPrefixes(
+def testGetNetworksForAsn_whenFirstResponseFails_retriesAndReturnsPrefixes(
     mocker: plugin.MockerFixture,
 ) -> None:
     """Retry a failed RIPE response and return the next valid response."""
@@ -131,9 +122,12 @@ def testFetchRipePrefixes_whenFirstResponseFails_retriesAndReturnsPrefixes(
         ],
     )
 
-    prefixes = _fetch_without_wait("AS268302")
+    networks = ipwhois_data_handler.get_networks_for_normalized_asn("AS268302")
 
-    assert prefixes == ["45.237.228.0/22", "2801:80:2400::/48", 42]
+    assert networks == [
+        ipaddress.ip_network("45.237.228.0/22"),
+        ipaddress.ip_network("2801:80:2400::/48"),
+    ]
     assert open_mock.call_count == 2
     request = open_mock.call_args.args[0]
     assert request.full_url.endswith("?resource=AS268302")
@@ -167,10 +161,11 @@ def testGetNetworksForAsn_normalizesAndExactlyDeduplicatesMixedPrefixes(
         ipaddress.ip_network("192.0.0.0/16"),
         ipaddress.ip_network("2001:db8:1::/48"),
     ]
-    fetch_mock.assert_called_once_with("AS268302")
+    assert fetch_mock.call_count == 1
+    assert fetch_mock.call_args.args == ("AS268302",)
 
 
-def testFetchRipePrefixes_buildsPublicRequestWithoutAuthentication(
+def testGetNetworksForAsn_buildsPublicRequestWithoutAuthentication(
     mocker: plugin.MockerFixture,
 ) -> None:
     """Use the public announced-prefixes endpoint without authorization."""
@@ -179,7 +174,7 @@ def testFetchRipePrefixes_buildsPublicRequestWithoutAuthentication(
         "urllib.request.urlopen", return_value=_json_response(response)
     )
 
-    assert _fetch_without_wait("AS15169") == []
+    assert ipwhois_data_handler.get_networks_for_normalized_asn("AS15169") == []
 
     request: mock.MagicMock = open_mock.call_args.args[0]
     assert "announced-prefixes" in request.full_url

--- a/tests/ipwhois_data_handler_test.py
+++ b/tests/ipwhois_data_handler_test.py
@@ -1,0 +1,187 @@
+"""Tests for ASN normalization and RIPE announced-prefix handling."""
+
+import http.client
+import ipaddress
+import json
+from io import BytesIO
+from unittest import mock
+
+import pytest
+import tenacity
+from pytest_mock import plugin
+
+from agent import ipwhois_data_handler
+
+
+def _json_response(payload: object) -> BytesIO:
+    """Build a context-manager response containing a JSON payload."""
+    return BytesIO(json.dumps(payload).encode("utf-8"))
+
+
+def _fetch_without_wait(normalized_asn: str) -> list[object]:
+    """Run the retrying RIPE fetch without sleeping in a unit test."""
+    fetch = ipwhois_data_handler._fetch_ripe_prefixes.retry_with(
+        wait=tenacity.wait_none()
+    )
+    return fetch(normalized_asn)
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("AS268302", "AS268302"),
+        ("as268302", "AS268302"),
+        ("268302", "AS268302"),
+        ("  AS268302  ", "AS268302"),
+        ("AS00268302", "AS268302"),
+        ("AS4294967295", "AS4294967295"),
+    ],
+)
+def testNormalizeAsn_whenValueIsValid_returnsCanonicalAsn(
+    value: object, expected: str
+) -> None:
+    """Canonicalize supported ASN spellings to one deduplication identity."""
+    assert ipwhois_data_handler.normalize_asn(value) == expected
+
+
+@pytest.mark.parametrize(
+    "value",
+    [None, 268302, "", "AS", "AS0", "AS-1", "AS1.5", "AS 1", "AS①", "AS4294967296"],
+)
+def testNormalizeAsn_whenValueIsInvalid_raisesValueError(value: object) -> None:
+    """Reject malformed, non-string, and out-of-range ASN values."""
+    with pytest.raises(ValueError, match="Invalid ASN"):
+        ipwhois_data_handler.normalize_asn(value)
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        [],
+        {},
+        {"status": "error", "data": {"prefixes": []}},
+        {"status": "ok", "data": None},
+        {"status": "ok", "data": {}},
+        {"status": "ok", "data": {"prefixes": {}}},
+    ],
+)
+def testFetchRipePrefixes_whenPayloadMalformed_raisesAfterRetries(
+    payload: object, mocker: plugin.MockerFixture
+) -> None:
+    """Treat malformed RIPE envelopes as retryable lookup failures."""
+    responses = [
+        _json_response(payload)
+        for _ in range(ipwhois_data_handler.RIPE_LOOKUP_ATTEMPTS)
+    ]
+    open_mock = mocker.patch("urllib.request.urlopen", side_effect=responses)
+
+    with pytest.raises(ipwhois_data_handler.RipeLookupError):
+        _fetch_without_wait("AS268302")
+
+    assert open_mock.call_count == ipwhois_data_handler.RIPE_LOOKUP_ATTEMPTS
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        TimeoutError("read timed out"),
+        OSError("socket failed"),
+        http.client.IncompleteRead(b"partial", 10),
+    ],
+)
+def testFetchRipePrefixes_whenTransportOrReadFails_convertsAndRetries(
+    error: BaseException,
+    mocker: plugin.MockerFixture,
+) -> None:
+    """Convert supported transport/read failures and retry without waiting."""
+    open_mock = mocker.patch(
+        "urllib.request.urlopen",
+        side_effect=[error for _ in range(ipwhois_data_handler.RIPE_LOOKUP_ATTEMPTS)],
+    )
+
+    with pytest.raises(ipwhois_data_handler.RipeLookupError) as exc_info:
+        _fetch_without_wait("AS268302")
+
+    assert open_mock.call_count == ipwhois_data_handler.RIPE_LOOKUP_ATTEMPTS
+    assert isinstance(exc_info.value.__cause__, type(error))
+
+
+def testFetchRipePrefixes_whenFirstResponseFails_retriesAndReturnsPrefixes(
+    mocker: plugin.MockerFixture,
+) -> None:
+    """Retry a failed RIPE response and return the next valid response."""
+    invalid_response = {"status": "error", "data": {"prefixes": []}}
+    valid_response = {
+        "status": "ok",
+        "data": {
+            "prefixes": [
+                {"prefix": "45.237.228.0/22", "timelines": []},
+                {"prefix": "2801:80:2400::/48"},
+                {"prefix": 42},
+                None,
+                {},
+            ]
+        },
+    }
+    open_mock = mocker.patch(
+        "urllib.request.urlopen",
+        side_effect=[
+            _json_response(invalid_response),
+            _json_response(valid_response),
+        ],
+    )
+
+    prefixes = _fetch_without_wait("AS268302")
+
+    assert prefixes == ["45.237.228.0/22", "2801:80:2400::/48", 42]
+    assert open_mock.call_count == 2
+    request = open_mock.call_args.args[0]
+    assert request.full_url.endswith("?resource=AS268302")
+    assert open_mock.call_args.kwargs["timeout"] == (
+        ipwhois_data_handler.RIPE_LOOKUP_TIMEOUT_SECONDS
+    )
+
+
+def testGetNetworksForAsn_normalizesAndExactlyDeduplicatesMixedPrefixes(
+    mocker: plugin.MockerFixture,
+) -> None:
+    """Canonicalize both IP families while preserving overlapping prefixes."""
+    fetch_mock = mocker.patch(
+        "agent.ipwhois_data_handler._fetch_ripe_prefixes",
+        return_value=[
+            "192.0.2.7/24",
+            "192.0.2.0/24",
+            "192.0.0.0/16",
+            " 2001:db8:1::42/48 ",
+            "2001:db8:1::/48",
+            "not-a-network",
+            42,
+            None,
+        ],
+    )
+
+    networks = ipwhois_data_handler.get_networks_for_normalized_asn("AS268302")
+
+    assert networks == [
+        ipaddress.ip_network("192.0.2.0/24"),
+        ipaddress.ip_network("192.0.0.0/16"),
+        ipaddress.ip_network("2001:db8:1::/48"),
+    ]
+    fetch_mock.assert_called_once_with("AS268302")
+
+
+def testFetchRipePrefixes_buildsPublicRequestWithoutAuthentication(
+    mocker: plugin.MockerFixture,
+) -> None:
+    """Use the public announced-prefixes endpoint without authorization."""
+    response = {"status": "ok", "data": {"prefixes": []}}
+    open_mock = mocker.patch(
+        "urllib.request.urlopen", return_value=_json_response(response)
+    )
+
+    assert _fetch_without_wait("AS15169") == []
+
+    request: mock.MagicMock = open_mock.call_args.args[0]
+    assert "announced-prefixes" in request.full_url
+    assert request.full_url.endswith("?resource=AS15169")
+    assert request.get_header("Authorization") is None

--- a/tests/ipwhois_data_handler_test.py
+++ b/tests/ipwhois_data_handler_test.py
@@ -1,9 +1,9 @@
 """Tests for ASN normalization and RIPE announced-prefix handling."""
 
 import http.client
+import io
 import ipaddress
 import json
-from io import BytesIO
 from unittest import mock
 
 import pytest
@@ -12,9 +12,9 @@ from pytest_mock import plugin
 from agent import ipwhois_data_handler
 
 
-def _json_response(payload: object) -> BytesIO:
+def _json_response(payload: object) -> io.BytesIO:
     """Build a context-manager response containing a JSON payload."""
-    return BytesIO(json.dumps(payload).encode("utf-8"))
+    return io.BytesIO(json.dumps(payload).encode("utf-8"))
 
 
 @pytest.mark.parametrize(

--- a/tests/ipwhois_data_handler_test.py
+++ b/tests/ipwhois_data_handler_test.py
@@ -37,11 +37,18 @@ def testNormalizeAsn_whenValueIsValid_returnsCanonicalAsn(
 
 @pytest.mark.parametrize(
     "value",
-    [None, 268302, "", "AS", "AS0", "AS-1", "AS1.5", "AS 1", "AS①", "AS4294967296"],
+    ["", "AS", "AS0", "AS-1", "AS1.5", "AS 1", "AS①", "AS4294967296"],
 )
-def testNormalizeAsn_whenValueIsInvalid_raisesValueError(value: object) -> None:
-    """Reject malformed, non-string, and out-of-range ASN values."""
+def testNormalizeAsn_whenValueIsMalformed_raisesValueError(value: object) -> None:
+    """Reject malformed and out-of-range ASN values."""
     with pytest.raises(ValueError, match="Invalid ASN"):
+        ipwhois_data_handler.normalize_asn(value)
+
+
+@pytest.mark.parametrize("value", [None, 268302])
+def testNormalizeAsn_whenValueIsNotAString_raisesTypeError(value: object) -> None:
+    """Reject non-string ASN values."""
+    with pytest.raises(TypeError, match="Invalid ASN"):
         ipwhois_data_handler.normalize_asn(value)
 
 

--- a/tests/whois_ip_agent_test.py
+++ b/tests/whois_ip_agent_test.py
@@ -1,5 +1,6 @@
 """Unittests for WhoisIP agent."""
 
+import ipaddress
 from unittest import mock
 
 import ipwhois
@@ -7,6 +8,7 @@ import pytest
 from ostorlab.agent.message import message
 from pytest_mock import plugin
 
+from agent import ipwhois_data_handler
 from agent import whois_ip_agent
 
 
@@ -369,3 +371,245 @@ def testWhoisIp_whenASNParseErrorOccure_logWithoutCrash(
 
     assert len(agent_mock) == 0
     assert "ASN parse error for IP" in caplog.text
+
+
+def _asn_message(asn: object, description: str | None = None) -> message.Message:
+    """Build an ASN message without requiring the unreleased OXO serializer."""
+    data = {"asn": asn}
+    if description is not None:
+        data["description"] = description
+    return message.Message(selector="v3.asset.asn", data=data, raw=b"")
+
+
+def testAgentWhoisIP_whenAsnSelector_emitsCanonicalSingletonNetworkMessages(
+    test_agent: whois_ip_agent.WhoisIPAgent,
+    agent_persist_mock: dict[str | bytes, str | bytes],
+    mocker: plugin.MockerFixture,
+) -> None:
+    """Route ASN input to RIPE and emit canonical IPv4 and IPv6 ranges."""
+    del agent_persist_mock
+    networks = [
+        ipaddress.ip_network("45.237.228.7/22", strict=False),
+        ipaddress.ip_network("2001:db8:1234::42/48", strict=False),
+    ]
+    lookup_mock = mocker.patch(
+        "agent.ipwhois_data_handler.get_networks_for_normalized_asn",
+        return_value=networks,
+    )
+    emit_mock = mocker.patch.object(test_agent, "emit")
+    process_ip_mock = mocker.patch.object(test_agent, "_process_ip")
+    whois_mock = mocker.patch("agent.whois_ip_agent._get_whois_record")
+
+    test_agent.process(
+        _asn_message(" as0268302 ", description="found from organization keyword")
+    )
+
+    lookup_mock.assert_called_once_with("AS268302")
+    assert emit_mock.call_args_list == [
+        mock.call(
+            "v3.asset.network",
+            {"ips": [{"host": "45.237.228.0", "mask": "22", "version": 4}]},
+        ),
+        mock.call(
+            "v3.asset.network",
+            {"ips": [{"host": "2001:db8:1234::", "mask": "48", "version": 6}]},
+        ),
+    ]
+    process_ip_mock.assert_not_called()
+    whois_mock.assert_not_called()
+
+
+def testAgentWhoisIP_whenSelectorOnlyContainsAsnData_doesNotExpand(
+    test_agent: whois_ip_agent.WhoisIPAgent,
+    mocker: plugin.MockerFixture,
+) -> None:
+    """Require the exact ASN selector instead of routing by data shape."""
+    lookup_mock = mocker.patch(
+        "agent.ipwhois_data_handler.get_networks_for_normalized_asn"
+    )
+    other_message = message.Message(
+        selector="v3.asset.organization", data={"asn": "AS268302"}, raw=b""
+    )
+
+    test_agent.process(other_message)
+
+    lookup_mock.assert_not_called()
+
+
+@pytest.mark.parametrize("asn", [None, "", "AS", "AS0", "ASinvalid", 268302])
+def testAgentWhoisIP_whenAsnInvalid_doesNotLookUpOrPersist(
+    asn: object,
+    test_agent: whois_ip_agent.WhoisIPAgent,
+    agent_persist_mock: dict[str | bytes, str | bytes],
+    mocker: plugin.MockerFixture,
+) -> None:
+    """Safely reject invalid ASN assets before lookup or persistence."""
+    lookup_mock = mocker.patch(
+        "agent.ipwhois_data_handler.get_networks_for_normalized_asn"
+    )
+    emit_mock = mocker.patch.object(test_agent, "emit")
+
+    test_agent.process(_asn_message(asn))
+
+    lookup_mock.assert_not_called()
+    emit_mock.assert_not_called()
+    assert agent_persist_mock == {}
+
+
+def testAgentWhoisIP_whenNetworksOverlap_deduplicatesOnlyExactCidr(
+    test_agent: whois_ip_agent.WhoisIPAgent,
+    agent_persist_mock: dict[str | bytes, str | bytes],
+    mocker: plugin.MockerFixture,
+) -> None:
+    """Emit a supernet and subnet while suppressing an exact duplicate."""
+    del agent_persist_mock
+    mocker.patch(
+        "agent.ipwhois_data_handler.get_networks_for_normalized_asn",
+        return_value=[
+            ipaddress.ip_network("192.0.0.0/16"),
+            ipaddress.ip_network("192.0.2.0/24"),
+            ipaddress.ip_network("192.0.2.0/24"),
+        ],
+    )
+    emit_mock = mocker.patch.object(test_agent, "emit")
+
+    test_agent.process(_asn_message("AS268302"))
+
+    assert [call.args[1]["ips"][0] for call in emit_mock.call_args_list] == [
+        {"host": "192.0.0.0", "mask": "16", "version": 4},
+        {"host": "192.0.2.0", "mask": "24", "version": 4},
+    ]
+
+
+def testAgentWhoisIP_whenAsnSucceeds_marksProcessedOnlyAfterEmission(
+    test_agent: whois_ip_agent.WhoisIPAgent,
+    agent_persist_mock: dict[str | bytes, str | bytes],
+    mocker: plugin.MockerFixture,
+) -> None:
+    """Do not mark an ASN processed until lookup and every emit succeed."""
+    processed_set = whois_ip_agent.ASN_PROCESSED_SET
+
+    def _is_processed() -> bool:
+        return "AS268302" in agent_persist_mock.get(processed_set, set())
+
+    def _lookup(normalized_asn: str) -> list[ipaddress.IPv4Network]:
+        assert normalized_asn == "AS268302"
+        assert _is_processed() is False
+        return [ipaddress.ip_network("45.237.228.0/22")]
+
+    def _emit(selector: str, data: dict[str, object]) -> None:
+        assert selector == "v3.asset.network"
+        assert data["ips"]
+        assert _is_processed() is False
+
+    mocker.patch(
+        "agent.ipwhois_data_handler.get_networks_for_normalized_asn",
+        side_effect=_lookup,
+    )
+    mocker.patch.object(test_agent, "emit", side_effect=_emit)
+
+    test_agent.process(_asn_message("AS268302"))
+
+    assert _is_processed() is True
+
+
+def testAgentWhoisIP_whenAsnLookupFails_messageRemainsRetryable(
+    test_agent: whois_ip_agent.WhoisIPAgent,
+    agent_persist_mock: dict[str | bytes, str | bytes],
+    mocker: plugin.MockerFixture,
+) -> None:
+    """Release transient state and retry a failed ASN lookup on redelivery."""
+    network = ipaddress.ip_network("45.237.228.0/22")
+    lookup_mock = mocker.patch(
+        "agent.ipwhois_data_handler.get_networks_for_normalized_asn",
+        side_effect=[
+            ipwhois_data_handler.RipeLookupError("RIPE unavailable"),
+            [network],
+        ],
+    )
+    emit_mock = mocker.patch.object(test_agent, "emit")
+    asn_message = _asn_message("AS268302")
+
+    with pytest.raises(ipwhois_data_handler.RipeLookupError):
+        test_agent.process(asn_message)
+
+    assert agent_persist_mock == {}
+
+    test_agent.process(asn_message)
+
+    assert lookup_mock.call_count == 2
+    emit_mock.assert_called_once()
+    assert "AS268302" in agent_persist_mock[whois_ip_agent.ASN_PROCESSED_SET]
+
+
+def testAgentWhoisIP_whenNetworkEmitFails_releasesClaimsAndRetries(
+    test_agent: whois_ip_agent.WhoisIPAgent,
+    agent_persist_mock: dict[str | bytes, str | bytes],
+    mocker: plugin.MockerFixture,
+) -> None:
+    """Rollback ASN and CIDR claims so a failed emit can be retried."""
+    network = ipaddress.ip_network("45.237.228.0/22")
+    lookup_mock = mocker.patch(
+        "agent.ipwhois_data_handler.get_networks_for_normalized_asn",
+        return_value=[network],
+    )
+    emit_mock = mocker.patch.object(
+        test_agent, "emit", side_effect=[RuntimeError("bus down"), None]
+    )
+    asn_message = _asn_message("AS268302")
+
+    with pytest.raises(RuntimeError, match="bus down"):
+        test_agent.process(asn_message)
+
+    assert agent_persist_mock == {}
+
+    test_agent.process(asn_message)
+
+    assert lookup_mock.call_count == 2
+    assert emit_mock.call_count == 2
+    assert "AS268302" in agent_persist_mock[whois_ip_agent.ASN_PROCESSED_SET]
+
+
+def testAgentWhoisIP_whenNetworkClaimIsConcurrent_doesNotMarkAsnProcessed(
+    test_agent: whois_ip_agent.WhoisIPAgent,
+    agent_persist_mock: dict[str | bytes, str | bytes],
+    mocker: plugin.MockerFixture,
+) -> None:
+    """Keep the ASN retryable while another worker owns a network claim."""
+    cidr = "45.237.228.0/22"
+    network_claim_key = f"{whois_ip_agent.NETWORK_CLAIM_KEY_PREFIX}:{cidr}"
+    agent_persist_mock[network_claim_key] = {cidr}
+    mocker.patch(
+        "agent.ipwhois_data_handler.get_networks_for_normalized_asn",
+        return_value=[ipaddress.ip_network(cidr)],
+    )
+    emit_mock = mocker.patch.object(test_agent, "emit")
+
+    with pytest.raises(whois_ip_agent.NetworkClaimError):
+        test_agent.process(_asn_message("AS268302"))
+
+    emit_mock.assert_not_called()
+    assert whois_ip_agent.ASN_PROCESSED_SET not in agent_persist_mock
+    assert f"{whois_ip_agent.ASN_CLAIM_KEY_PREFIX}:AS268302" not in agent_persist_mock
+    assert agent_persist_mock[network_claim_key] == {cidr}
+
+
+def testAgentWhoisIP_whenIpWhoisContainsAsn_doesNotCallRipe(
+    scan_message_ipv4: message.Message,
+    test_agent: whois_ip_agent.WhoisIPAgent,
+    agent_mock: list[message.Message],
+    agent_persist_mock: dict[str | bytes, str | bytes],
+    mock_whois_lookup: None,
+    mocker: plugin.MockerFixture,
+) -> None:
+    """Keep IP WHOIS independent from ASN-to-network expansion."""
+    del agent_persist_mock, mock_whois_lookup
+    lookup_mock = mocker.patch(
+        "agent.ipwhois_data_handler.get_networks_for_normalized_asn"
+    )
+
+    test_agent.process(scan_message_ipv4)
+
+    lookup_mock.assert_not_called()
+    assert len(agent_mock) == 1
+    assert agent_mock[0].selector == "v3.asset.ip.v4.whois"

--- a/tests/whois_ip_agent_test.py
+++ b/tests/whois_ip_agent_test.py
@@ -9,8 +9,7 @@ import pytest
 from ostorlab.agent.message import message
 from pytest_mock import plugin
 
-from agent import ipwhois_data_handler
-from agent import whois_ip_agent
+from agent import ipwhois_data_handler, whois_ip_agent
 
 
 def testAgentWhoisIP_whenIPv4Target_returnsWhoisRecord(

--- a/tests/whois_ip_agent_test.py
+++ b/tests/whois_ip_agent_test.py
@@ -1,6 +1,7 @@
 """Unittests for WhoisIP agent."""
 
 import ipaddress
+from typing import Any
 from unittest import mock
 
 import ipwhois
@@ -492,7 +493,9 @@ def testAgentWhoisIP_whenAsnSucceeds_marksProcessedOnlyAfterEmission(
     def _is_processed() -> bool:
         return "AS268302" in agent_persist_mock.get(processed_set, set())
 
-    def _lookup(normalized_asn: str) -> list[ipaddress.IPv4Network]:
+    def _lookup(
+        normalized_asn: str,
+    ) -> list[ipaddress.IPv4Network | ipaddress.IPv6Network]:
         assert normalized_asn == "AS268302"
         assert _is_processed() is False
         return [ipaddress.ip_network("45.237.228.0/22")]
@@ -570,9 +573,41 @@ def testAgentWhoisIP_whenNetworkEmitFails_releasesClaimsAndRetries(
     assert "AS268302" in agent_persist_mock[whois_ip_agent.ASN_PROCESSED_SET]
 
 
+def testAgentWhoisIP_whenOneNetworkIsClaimed_stillEmitsTheRemainingNetworks(
+    test_agent: whois_ip_agent.WhoisIPAgent,
+    agent_persist_mock: dict[str | bytes, Any],
+    mocker: plugin.MockerFixture,
+) -> None:
+    """Emit every free network even when an earlier one is owned by another worker."""
+    claimed_cidr = "45.237.228.0/22"
+    free_cidr = "2801:80:2400::/48"
+    agent_persist_mock[f"{whois_ip_agent.NETWORK_CLAIM_KEY_PREFIX}:{claimed_cidr}"] = {
+        claimed_cidr
+    }
+    mocker.patch(
+        "agent.ipwhois_data_handler.get_networks_for_normalized_asn",
+        return_value=[
+            ipaddress.ip_network(claimed_cidr),
+            ipaddress.ip_network(free_cidr),
+        ],
+    )
+    emit_mock = mocker.patch.object(test_agent, "emit")
+
+    with pytest.raises(whois_ip_agent.NetworkClaimError):
+        test_agent.process(_asn_message("AS268302"))
+
+    assert emit_mock.call_count == 1
+    assert emit_mock.call_args.args == (
+        "v3.asset.network",
+        {"ips": [{"host": "2801:80:2400::", "mask": "48", "version": 6}]},
+    )
+    assert whois_ip_agent.ASN_PROCESSED_SET not in agent_persist_mock
+    assert free_cidr in agent_persist_mock[whois_ip_agent.NETWORK_PROCESSED_SET]
+
+
 def testAgentWhoisIP_whenNetworkClaimIsConcurrent_doesNotMarkAsnProcessed(
     test_agent: whois_ip_agent.WhoisIPAgent,
-    agent_persist_mock: dict[str | bytes, str | bytes],
+    agent_persist_mock: dict[str | bytes, Any],
     mocker: plugin.MockerFixture,
 ) -> None:
     """Keep the ASN retryable while another worker owns a network claim."""
@@ -588,7 +623,7 @@ def testAgentWhoisIP_whenNetworkClaimIsConcurrent_doesNotMarkAsnProcessed(
     with pytest.raises(whois_ip_agent.NetworkClaimError):
         test_agent.process(_asn_message("AS268302"))
 
-    emit_mock.assert_not_called()
+    assert emit_mock.called is False
     assert whois_ip_agent.ASN_PROCESSED_SET not in agent_persist_mock
     assert f"{whois_ip_agent.ASN_CLAIM_KEY_PREFIX}:AS268302" not in agent_persist_mock
     assert agent_persist_mock[network_claim_key] == {cidr}


### PR DESCRIPTION
## Summary

- Consume only v3.asset.asn as the standalone ASN expansion input.
- Normalize AS-prefixed, lowercase, numeric-only, and zero-padded ASN values.
- Query the public RIPE announced-prefixes API without authentication.
- Canonicalize and exactly deduplicate IPv4 and IPv6 CIDRs while preserving distinct overlapping announcements.
- Emit one v3.asset.network message per CIDR using the existing singleton ips payload with host, mask, and version.
- Keep ASN, CIDR in-flight claims, and completed markers separate so lookup and emission failures remain retryable.
- Preserve the existing IP and DNS WHOIS paths unchanged.

The agent never emits ASN-derived ranges as v3.asset.ip.v4 or v3.asset.ip.v6, never calls network.hosts for ASN input, and does not initiate scanning, assert ownership, or persist an ASN-to-network graph relationship.

Example output for 45.237.228.0/22:

    {
      "ips": [
        {
          "host": "45.237.228.0",
          "mask": "22",
          "version": 4
        }
      ]
    }

## Verification

- Pytest: 59 passed
- Ruff format and check: passed
- Mypy: passed
- Cross-repository serializer check with OXO #1160: passed for ASN input and network output
- Live RIPE check: AS268302 returned IPv4 and IPv6 announcements, including 45.237.228.0/22 and 2801:80:2400::/48

## Integration order

Depends on Ostorlab/oxo#1160. Merge and release that message contract first, then build and deploy this agent so the runtime can deserialize v3.asset.asn.

This is the clean replacement for the closed #44 implementation.

Ticket: https://report.ostorlab.co/o/os/remediation/tickets/os-29817